### PR TITLE
Clean

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -11,6 +11,14 @@ then
   exit 1
 fi
 
+echo Checking for untracked files...
+UNTRACKED=$(git ls-files --other --exclude-standard)
+if [[ "$UNTRACKED" ]]
+then
+  printf "Untracked files!:\n%s\n" "$UNTRACKED"
+  exit 1
+fi
+
 # TODO(peterthenelson) Check for untracked files.
 
 echo Running lint...

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -4,6 +4,15 @@
 set -e
 cd "$(git rev-parse --show-toplevel)"
 
+echo Checking for unstaged changes...
+if ! UNSTAGED=$(git diff --name-only --exit-code)
+then
+  printf "Unstaged changes!:\n%s\n" "$UNSTAGED"
+  exit 1
+fi
+
+# TODO(peterthenelson) Check for untracked files.
+
 echo Running lint...
 scripts/lint.sh
 

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -19,8 +19,6 @@ then
   exit 1
 fi
 
-# TODO(peterthenelson) Check for untracked files.
-
 echo Running lint...
 scripts/lint.sh
 


### PR DESCRIPTION
Closes #42. Presubmit will now fail if you delete a file without using "git rm" or if you add or modify a file without then "git add"ing it. This means that the precommit tests and lint are actually running on what will be committed (which seems like an important feature).
